### PR TITLE
 Wifi parameters fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ interrupt the sequence by e.g. deleting or renaming init.lua file (see
 This configuration file defines the SSID and password needed to connect to your WiFi
 network, for example:
 ```lua
-ssid = "xxxxxxxx"
-pwd = "xxxxxxxx"
+station_cfg={}
+station_cfg.ssid="....."
+station_cfg.pwd="...."
 ```
-
+See https://nodemcu.readthedocs.io/en/master/en/modules/wifi/#wifistaconfig
 
 ### Base component: *startup.lua*
 

--- a/src/config_net.lua
+++ b/src/config_net.lua
@@ -1,0 +1,11 @@
+
+-- load credentials, 'ssid' and 'pwd'
+-- https://nodemcu.readthedocs.io/en/master/en/modules/wifi/#wifistaconfig 
+-- Called in init.lua
+
+--connect to Access Point (DO NOT save config to flash)
+station_cfg={}
+station_cfg.ssid="Your SSID"
+station_cfg.pwd="Your pwd"
+station_cfg.save=false
+

--- a/src/init.lua
+++ b/src/init.lua
@@ -1,7 +1,7 @@
 -- LGPL v3 License (Free Software Foundation)
 -- Copyright (C) 2017 -2018 ScalAgent Distributed Technologies
 
--- load credentials, 'ssid' and 'pwd'
+-- load 'station_cfg' containing WiFi config: 'ssid' and 'pwd'
 dofile("config_net.lua")
 
 function run()
@@ -11,7 +11,7 @@ end
 function connect()
   print("Connecting to WiFi access point...")
   wifi.setmode(wifi.STATION)
-  wifi.sta.config(ssid, pwd)
+  wifi.sta.config(station_cfg)
 
   tmr.create():alarm(1000, tmr.ALARM_AUTO, function(cb_timer)
     if wifi.sta.getip() == nil then


### PR DESCRIPTION
According to the doc https://nodemcu.readthedocs.io/en/master/en/modules/wifi/#wifistaconfig and my experience the Wifi parameters are in a structure.

There is a risk that the user commits its wifi pwd to GitHub. Maybe a `.gitignore` would help? 